### PR TITLE
Gate @claude dispatch to core-team members; drop peter-evans dispatch action

### DIFF
--- a/.github/workflows/claude-dispatch.yml
+++ b/.github/workflows/claude-dispatch.yml
@@ -23,29 +23,44 @@ jobs:
       )
     runs-on: ubuntu-latest
     steps:
-      - name: Build payload
-        id: payload
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const payload = {
-              issue_number: context.issue.number,
-              issue_url: context.payload.issue.html_url,
-              issue_title: context.payload.issue.title,
-              comment_id: context.payload.comment?.id || 0,
-              comment_url: context.payload.comment?.html_url || '',
-              comment_body: context.payload.comment?.body || '',
-              issue_body: context.payload.issue.body || '',
-              sender: context.payload.sender.login,
-              event_name: context.eventName,
-              repo_full_name: context.payload.repository.full_name
-            };
-            core.setOutput('json', JSON.stringify(payload));
-
       - name: Dispatch to twenty
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.TWENTY_DISPATCH_TOKEN }}
-          repository: twentyhq/twenty
-          event-type: claude-core-team-issues
-          client-payload: ${{ steps.payload.outputs.json }}
+        env:
+          GH_TOKEN: ${{ secrets.TWENTY_DISPATCH_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          COMMENT_URL: ${{ github.event.comment.html_url }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          SENDER: ${{ github.event.sender.login }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPO_FULL_NAME: ${{ github.event.repository.full_name }}
+        run: |
+          jq -n \
+            --argjson issue_number "${ISSUE_NUMBER:-0}" \
+            --arg     issue_url "$ISSUE_URL" \
+            --arg     issue_title "$ISSUE_TITLE" \
+            --arg     issue_body "$ISSUE_BODY" \
+            --argjson comment_id "${COMMENT_ID:-0}" \
+            --arg     comment_url "$COMMENT_URL" \
+            --arg     comment_body "$COMMENT_BODY" \
+            --arg     sender "$SENDER" \
+            --arg     event_name "$EVENT_NAME" \
+            --arg     repo_full_name "$REPO_FULL_NAME" \
+            '{
+              event_type: "claude-core-team-issues",
+              client_payload: {
+                issue_number: $issue_number,
+                issue_url: $issue_url,
+                issue_title: $issue_title,
+                issue_body: $issue_body,
+                comment_id: $comment_id,
+                comment_url: $comment_url,
+                comment_body: $comment_body,
+                sender: $sender,
+                event_name: $event_name,
+                repo_full_name: $repo_full_name
+              }
+            }' \
+          | gh api --method POST /repos/twentyhq/twenty/dispatches --input -

--- a/.github/workflows/claude-dispatch.yml
+++ b/.github/workflows/claude-dispatch.yml
@@ -9,8 +9,18 @@ on:
 jobs:
   dispatch:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        github.event.comment.user.type != 'Bot' &&
+        contains(fromJson('["OWNER","MEMBER"]'), github.event.comment.author_association)
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        github.event.issue.user.type != 'Bot' &&
+        contains(fromJson('["OWNER","MEMBER"]'), github.event.issue.author_association)
+      )
     runs-on: ubuntu-latest
     steps:
       - name: Build payload


### PR DESCRIPTION
## Summary

Closes an authorization gap in `claude-dispatch.yml`. The `dispatch` job forwarded **any** issue or comment containing `@claude` to `twentyhq/twenty` via the privileged `TWENTY_DISPATCH_TOKEN`, with no check on who authored it.

Because this repo is **public**, any GitHub user could open or comment on an issue and have their attacker-controlled text delivered as the prompt to the write-capable `claude-cross-repo` agent in `twentyhq/twenty` — a confused-deputy path into a job that holds `contents`/`pull-requests`/`issues: write` and broad shell tools. The receiver has no author data to authorize on, so the gate must live here at the source.

## Changes

- **Gate the `dispatch` job on `author_association`** — it now fires only when the issue/comment author is `OWNER` or `MEMBER` (org / core-team members) and is not a bot. `COLLABORATOR` is intentionally excluded: on a public repo it can include outside collaborators who are not core team.
- **Replace `peter-evans/repository-dispatch` with the built-in `gh` CLI** — the dispatch now calls the repository-dispatches API directly (`gh api … /dispatches`), removing a third-party action from the privileged, token-holding step. The `repository_dispatch` event type and `client_payload` contract are unchanged, so `twentyhq/twenty` needs **no update** and the token still only needs `contents: write`.
- Untrusted issue/comment fields are passed through the `env` block and JSON-encoded with `jq --arg`, so a quote or newline in a title/body can neither break the JSON body nor be interpreted by the shell.

## Audit

Reviewed the full GitHub Actions history on both repos: the dispatch path only ever fired during core-team testing on 2026-02-02 (all runs authored by a core-team member), and not since. No third-party or malicious runs.

## Follow-ups (outside this repo)

- **Rotate `TWENTY_DISPATCH_TOKEN`** — the ungated path was live on a public repo, so treat the token as potentially exposed.
- **Optional receiver hardening in `twenty`** — a required-approval Environment on `claude-cross-repo` is the only control that survives a token leak; a payload-based author re-check is not, since `client_payload` is attacker-forgeable by anyone holding the dispatch token.

## Testing

- `claude-dispatch.yml` validated as well-formed YAML.
- No third-party actions remain in the workflow; change is confined to the job-level `if` and the dispatch step.

## Credits
Reported by @reindaelman, many thanks !